### PR TITLE
Fix/pointclouds from cams

### DIFF
--- a/src/online_simulator/simulator.cpp
+++ b/src/online_simulator/simulator.cpp
@@ -308,6 +308,8 @@ bool AirsimSimulator::setupROS() {
       // the auto-generated-config.
       camera->camera_info = airsim_move_client_.simGetCameraInfo(
               camera->name, config_.vehicle_name);
+      // TODO(Schmluk): Might want to also publish the camera info or convert
+      // to intrinsics etc
      }
 
     if (!config_.publish_sensor_transforms) {
@@ -317,8 +319,6 @@ bool AirsimSimulator::setupROS() {
       if (config_.sensors[i]->sensor_type == Config::Sensor::TYPE_CAMERA) {
         // Camera frames are x right, y down, z depth
         rotation = Eigen::Quaterniond(0.5, -0.5, 0.5, -0.5) * rotation;
-        // TODO(Schmluk): Might want to also publish the camera info or convert
-        // to intrinsics etc
       }
       static_transformStamped.header.stamp = ros::Time::now();
       static_transformStamped.header.frame_id = config_.vehicle_name;

--- a/src/online_simulator/simulator.cpp
+++ b/src/online_simulator/simulator.cpp
@@ -42,7 +42,6 @@ AirsimSimulator::AirsimSimulator(const ros::NodeHandle& nh,
           OdometryDriftSimulator::Config::fromRosParams(nh_private)) {
   // configure
   readParamsFromRos();
-std::cout << "Hi " << std::endl;
 
   // airsim
   bool success = setupAirsim();


### PR DESCRIPTION
Publishing fused pointclouds from RGB + Depth does not work without havin set the publish_sensor_transform.

Problem: focal_length_ calculated [here](https://github.com/ethz-asl/unreal_airsim/blob/d8a2edfdc5f6ecdaf86cb16c3762e98fc082ae92/src/simulator_processing/depth_to_pointcloud.cpp#L112) is assigned a inf value, since the variable fov_ is zero.

Loading camera informations sets the fov_ variable and fixes this problem.

There might be a better solution for this, just opening the pull request, to raise awareness.

