### PR TITLE
fixed crashes in depth to point cloud conversion

### DIFF
--- a/include/unreal_airsim/simulator_processing/depth_to_pointcloud.h
+++ b/include/unreal_airsim/simulator_processing/depth_to_pointcloud.h
@@ -8,6 +8,7 @@
 #include <sensor_msgs/Image.h>
 
 #include <deque>
+#include <mutex>
 #include <string>
 
 namespace unreal_airsim::simulator_processor {
@@ -39,6 +40,7 @@ class DepthToPointcloud : public ProcessorBase {
   ros::Subscriber segmentation_sub_;
 
   // queues
+  std::mutex queue_guard;
   std::deque<sensor_msgs::ImagePtr> depth_queue_;
   std::deque<sensor_msgs::ImagePtr> color_queue_;
   std::deque<sensor_msgs::ImagePtr> segmentation_queue_;

--- a/src/simulator_processing/depth_to_pointcloud.cpp
+++ b/src/simulator_processing/depth_to_pointcloud.cpp
@@ -147,6 +147,8 @@ void DepthToPointcloud::findMatchingMessagesToPublish(
   // If a modality is not used we count it as found.
   bool found_color = true;
   bool found_segmentation = true;
+  
+  std::lock_guard<std::mutex> guard(queue_guard);
 
   depth_it =
       std::find_if(depth_queue_.begin(), depth_queue_.end(),


### PR DESCRIPTION
The commit fixes crashes caused by deleting depth images from thread unsafe queue during image callbacks for depth, color and segmentation images (from multiple threads as simulation is using asyncspinner).