### PR TITLE
Fixed crashes due to unhandeled exception in infrared_id_compensation code

### DIFF
--- a/src/simulator_processing/infrared_id_compensation.cpp
+++ b/src/simulator_processing/infrared_id_compensation.cpp
@@ -54,14 +54,20 @@ bool InfraredIdCompensation::setupFromRos(const ros::NodeHandle& nh,
 }
 
 void InfraredIdCompensation::imageCallback(const sensor_msgs::ImagePtr& msg) {
-  cv_bridge::CvImagePtr img = cv_bridge::toCvCopy(msg, msg->encoding);
-  for (int v = 0; v < img->image.rows; v++) {
-    for (int u = 0; u < img->image.cols; u++) {
-      img->image.at<uchar>(v, u) =
-          infrared_compensation_[img->image.at<uchar>(v, u)];
+  try {
+    cv_bridge::CvImagePtr img = cv_bridge::toCvCopy(msg, msg->encoding);
+
+    for (int v = 0; v < img->image.rows; v++) {
+      for (int u = 0; u < img->image.cols; u++) {
+        img->image.at<uchar>(v, u) =
+            infrared_compensation_[img->image.at<uchar>(v, u)];
+      }
     }
+    pub_.publish(img->toImageMsg());
+  } catch (const cv_bridge::Exception& e) {
+    std::cerr << "Could not convert image to CvImage\n";
+    std::cout << e.what();
   }
-  pub_.publish(img->toImageMsg());
 }
 
 }  // namespace unreal_airsim::simulator_processor

--- a/src/simulator_processing/infrared_id_compensation.cpp
+++ b/src/simulator_processing/infrared_id_compensation.cpp
@@ -56,7 +56,6 @@ bool InfraredIdCompensation::setupFromRos(const ros::NodeHandle& nh,
 void InfraredIdCompensation::imageCallback(const sensor_msgs::ImagePtr& msg) {
   try {
     cv_bridge::CvImagePtr img = cv_bridge::toCvCopy(msg, msg->encoding);
-
     for (int v = 0; v < img->image.rows; v++) {
       for (int u = 0; u < img->image.cols; u++) {
         img->image.at<uchar>(v, u) =


### PR DESCRIPTION
Fixed crash during conversion of corrupt received image data to cv image.